### PR TITLE
Fix the wrong look-ahead for the TypeDecl rule

### DIFF
--- a/Source/DGrok.Framework/Framework/Parser.cs
+++ b/Source/DGrok.Framework/Framework/Parser.cs
@@ -1445,7 +1445,10 @@ namespace DGrok.Framework
             });
             #endregion
             #region TypeDecl
-            AddRule(RuleType.TypeDecl, TokenSets.Ident.LookAhead, delegate
+            AddRule(RuleType.TypeDecl, delegate
+            {
+                return TokenSets.Ident.LookAhead(this) && !TokenSets.Visibility.LookAhead(this);
+            }, delegate
             {
                 Token name = ParseIdent();
                 Token equalSign = ParseToken(TokenType.EqualSign);


### PR DESCRIPTION
Given the following code:

```
unit Unit1;
interface
type
    TMyClass = class
    private
        type
            TMyRec = record
            end;
    protected
        Foo: Integer;
    end;
implementation
end.
```

The parser incorrectly interprets the semi-keyword 'protected' as a
type identifier and issues the following error message: "Expected
EqualSign but found Identifier".

The visibility specifiers are indeed semi-keywords, i.e. they can in
certain situations be treated as identifiers (like procedure names
for instance). This however is an exception, where visibility specifiers
strict, private, public, protected and published (among other keywords
like procedure, class or type) explicitly terminate the nested type
declarations section.

The solution was simple: in a look-ahead procedure for the TypeDecl rule,
I added an additional constraint check for visibility semi-keywords. If
they are present, the rule is no longer accepted and the type section is
terminated.