### PR TITLE
Fix issue Failure to parse HIGHCHARUNICODE compiler directive

### DIFF
--- a/Source/DGrok.Framework/Framework/TokenFilter.cs
+++ b/Source/DGrok.Framework/Framework/TokenFilter.cs
@@ -86,6 +86,7 @@ namespace DGrok.Framework
             _directiveTypes["EXTENDEDSYNTAX"] = DirectiveType.Ignored;
             _directiveTypes["EXTENSION"] = DirectiveType.Ignored;
             _directiveTypes["FINITEFLOAT"] = DirectiveType.Ignored;
+            _directiveTypes["HIGHCHARUNICODE"] = DirectiveType.Ignored;
             _directiveTypes["HINTS"] = DirectiveType.Ignored;
             _directiveTypes["I"] = DirectiveType.PossibleInclude;
             _directiveTypes["IMAGEBASE"] = DirectiveType.Ignored;

--- a/Source/DGrok.Tests/TokenFilterTests.cs
+++ b/Source/DGrok.Tests/TokenFilterTests.cs
@@ -95,6 +95,12 @@ namespace DGrok.Tests
             Assert.That("{$NOINCLUDE Foo}", LexesAndFiltersAs());
         }
         [Test]
+        public void HighCharUnicodeCompilerDirectivesAreIgnored()
+        {
+            Assert.That("{$HIGHCHARUNICODE ON}", LexesAndFiltersAs());
+            Assert.That("{$HIGHCHARUNICODE OFF}", LexesAndFiltersAs());
+        }
+        [Test]
         public void IfDefTrue()
         {
             Assert.That("0{$IFDEF TRUE}1{$ENDIF}2", LexesAndFiltersAs(


### PR DESCRIPTION
Fix issue Failure to parse HIGHCHARUNICODE compiler directive
  https://github.com/joewhite/dgrok/issues/4

Add an ignored directive type for "HIGHCHARUNICODE"]
to Source/DGrok.Framework/Framework/TokenFilter.cs

Add a new test case HighCharUnicodeCompilerDirectivesAreIgnored()
to verifiy that {$HIGHCHARUNICODE ... } is ignored
  ( doesn't really check the value of the parameter ON/OFF )