### PR TITLE
Fix issue Failure to parse ZEROBASEDSTRINGS compiler directive

### DIFF
--- a/Source/DGrok.Framework/Framework/TokenFilter.cs
+++ b/Source/DGrok.Framework/Framework/TokenFilter.cs
@@ -133,6 +133,7 @@ namespace DGrok.Framework
             _directiveTypes["WARNINGS"] = DirectiveType.Ignored;
             _directiveTypes["WEAKPACKAGEUNIT"] = DirectiveType.Ignored;
             _directiveTypes["WRITEABLECONST"] = DirectiveType.Ignored;
+            _directiveTypes["ZEROBASEDSTRINGS"] = DirectiveType.Ignored;
             // Directives for generation of C++Builder .hpp files
             _directiveTypes["EXTERNALSYM"] = DirectiveType.Ignored;
             _directiveTypes["HPPEMIT"] = DirectiveType.Ignored;

--- a/Source/DGrok.Tests/TokenFilterTests.cs
+++ b/Source/DGrok.Tests/TokenFilterTests.cs
@@ -95,6 +95,12 @@ namespace DGrok.Tests
             Assert.That("{$NOINCLUDE Foo}", LexesAndFiltersAs());
         }
         [Test]
+        public void ZeroBasedStringsCompilerDirectivesAreIgnored()
+        {
+            Assert.That("{$ZEROBASEDSTRINGS ON}", LexesAndFiltersAs());
+            Assert.That("{$ZEROBASEDSTRINGS OFF}", LexesAndFiltersAs());
+        }
+        [Test]
         public void IfDefTrue()
         {
             Assert.That("0{$IFDEF TRUE}1{$ENDIF}2", LexesAndFiltersAs(


### PR DESCRIPTION
Fix issue Failure to parse ZEROBASEDSTRINGS compiler directive
  joewhite#6  https://github.com/joewhite/dgrok/issues/6

Add an ignored directive type for ZEROBASEDSTRINGS
to Source/DGrok.Framework/Framework/TokenFilter.cs

Add a new test case ZeroBasedStringsCompilerDirectivesAreIgnored()
to verifiy that {$ZEROBASEDSTRINGS ... } is ignored
  ( doesn't really check the value of the parameter ON/OFF )